### PR TITLE
Add CLI entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ packages = [{include = "efu_csv_utils", from = "src"}]
 [tool.poetry.dependencies]
 python = "^3.8"
 
+[tool.poetry.scripts]
+efu-csv-utils = "efu_csv_utils:main"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/efu_csv_utils/__init__.py
+++ b/src/efu_csv_utils/__init__.py
@@ -86,20 +86,28 @@ def write_efu(rows: List[List[str]], header_raw: str, file_path: str, newline: O
             f.write(','.join(out_fields) + nl)
 
 
-if __name__ == '__main__':
-    # Example usage
-    input_path = '/mnt/data/133.71.3.4-home.efu'
-    output_path = '/mnt/data/133.71.3.4-home_custom.efu'
+def main(argv: Optional[List[str]] = None) -> None:
+    """Command line interface for parsing and writing EFU files."""
+    import argparse
 
-    rows, header_raw, nl = parse_efu(input_path)
-    write_efu(rows, header_raw, output_path, newline=nl)
+    parser = argparse.ArgumentParser(description="Parse and write EFU files")
+    parser.add_argument("input", help="Path to the input EFU file")
+    parser.add_argument("output", help="Path to write the output EFU file")
+    args = parser.parse_args(argv)
+
+    rows, header_raw, nl = parse_efu(args.input)
+    write_efu(rows, header_raw, args.output, newline=nl)
 
     # Verify round-trip
-    with open(input_path, 'rb') as f:
+    with open(args.input, "rb") as f:
         orig = f.read()
-    with open(output_path, 'rb') as f:
+    with open(args.output, "rb") as f:
         new = f.read()
     if orig == new:
-        print('Round-trip successful: files are identical')
+        print("Round-trip successful: files are identical")
     else:
-        print('Round-trip failed: files differ')
+        print("Round-trip failed: files differ")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a small CLI using argparse and expose it in pyproject
- drop hard-coded paths in `__main__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ab0b13c9c832bb207cd10c4f7b15a