### PR TITLE
Modify header handling interface

### DIFF
--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -11,9 +11,9 @@ def test_roundtrip(tmp_path):
     root = pathlib.Path(__file__).resolve().parents[1]
     sample = root / 'samples' / 'sample1.efu'
 
-    rows, header_raw, nl = parse_efu(str(sample))
+    rows, header_fields, nl = parse_efu(str(sample))
     out_file = tmp_path / 'out.efu'
-    write_efu(rows, header_raw, str(out_file), newline=nl)
+    write_efu(rows, header_fields, str(out_file), newline=nl)
 
     with open(sample, 'rb') as f:
         original = f.read()


### PR DESCRIPTION
## Summary
- parse header line into list of strings
- accept header field list in `write_efu`
- adjust CLI and round-trip test
- update documentation to reflect header changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae773d22c832b9bc6bebd9fef9e37