### PR TITLE
Add parse_efu unit test

### DIFF
--- a/tests/test_parse_efu.py
+++ b/tests/test_parse_efu.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu_csv_utils import parse_efu
+
+
+def test_parse_efu_simple(tmp_path):
+    csv_content = (
+        "Filename,Size,Date Modified,Date Created,Attributes\r\n"
+        "\"C:\\msys64\",,133876022280081366,133739602603410395,16\r\n"
+        "\"C:\\msys64\\autorebase.bat\",82,133262362720000000,133739602600000000,32\r\n"
+        "\"C:\\msys64\\clang64\",0,133665511886007850,133665511886007850,16\r\n"
+    )
+
+    sample_file = tmp_path / "sample.efu"
+    sample_file.write_text(csv_content, newline="")
+
+    rows, header, nl = parse_efu(str(sample_file))
+
+    assert header == [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+    assert rows == [
+        ["C:\\msys64", "", "133876022280081366", "133739602603410395", "16"],
+        [
+            "C:\\msys64\\autorebase.bat",
+            "82",
+            "133262362720000000",
+            "133739602600000000",
+            "32",
+        ],
+        [
+            "C:\\msys64\\clang64",
+            "0",
+            "133665511886007850",
+            "133665511886007850",
+            "16",
+        ],
+    ]
+    assert nl == "\r\n"


### PR DESCRIPTION
## Summary
- add unit test for `parse_efu` using CSV sample from `docs/json.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ae8c38b34832bb6449d05d65a036b