### PR TITLE
Add write_efu unit test

### DIFF
--- a/tests/test_write_efu.py
+++ b/tests/test_write_efu.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu_csv_utils import write_efu
+
+
+def test_write_efu_simple(tmp_path):
+    header = [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+    rows = [
+        ["C:\\msys64", "", "133876022280081366", "133739602603410395", "16"],
+        [
+            "C:\\msys64\\autorebase.bat",
+            "82",
+            "133262362720000000",
+            "133739602600000000",
+            "32",
+        ],
+        [
+            "C:\\msys64\\clang64",
+            "0",
+            "133665511886007850",
+            "133665511886007850",
+            "16",
+        ],
+    ]
+
+    out_file = tmp_path / "out.efu"
+    write_efu(rows, header, str(out_file), newline="\r\n")
+
+    expected = (
+        "Filename,Size,Date Modified,Date Created,Attributes\r\n"
+        "\"C:\\msys64\",,133876022280081366,133739602603410395,16\r\n"
+        "\"C:\\msys64\\autorebase.bat\",82,133262362720000000,133739602600000000,32\r\n"
+        "\"C:\\msys64\\clang64\",0,133665511886007850,133665511886007850,16\r\n"
+    )
+
+    with open(out_file, "r", newline="") as f:
+        content = f.read()
+    assert content == expected


### PR DESCRIPTION
## Summary
- add a unit test for `write_efu`
- use the CSV snippet from `docs/json.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aeaa1009c832bb6f765a38daad5b6