### PR TITLE
Add parse_efu_objects to output dictionaries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,15 @@ def write_efu(
   * Fields with leading/trailing spaces are treated as text and quoted.
   * Zero-length value (`''`) always written as empty (no quotes): `, ,` yields `,,`.
 
+### 2.3 `parse_efu_objects`
+
+```python
+def parse_efu_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, Any]]
+```
+
+* **Returns**: List of dictionaries using header names as keys. Empty fields become
+  `None` and digit-only fields are converted to `int`.
+
 ---
 
 ## 3. Examples
@@ -134,7 +143,8 @@ write_efu(rows, header_fields, 'output.efu', newline=nl)
 
 ## 5. Limitations
 
-* Does not convert numeric strings to Python numeric types; all data remains strings.
+* `parse_efu` does not convert numeric strings to Python numeric types; use
+  `parse_efu_objects` for typed values.
 * ISO/locale-specific encodings other than UTF-8 must be specified.
 * No streaming: entire file is loaded into memory; may not scale for extremely large EFU files.
 

--- a/src/efu_csv_utils/__init__.py
+++ b/src/efu_csv_utils/__init__.py
@@ -1,7 +1,7 @@
 # efu_csv_utils.py
 # Custom CSV parser and serializer for Everything EFU files
 
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def parse_efu(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]], List[str], str]:
@@ -55,6 +55,31 @@ def parse_efu(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]],
         row.append(''.join(field))
         rows.append(row)
     return rows, header_fields, newline
+
+
+def parse_efu_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, Any]]:
+    """Parse an EFU file and return a list of row dictionaries.
+
+    Empty fields are converted to ``None`` and purely digit strings are
+    converted to ``int``. Keys are taken from the header row.
+    """
+
+    rows, header_fields, _ = parse_efu(file_path, encoding=encoding)
+
+    objects: List[Dict[str, Any]] = []
+    for row in rows:
+        obj: Dict[str, Any] = {}
+        for i, header in enumerate(header_fields):
+            value = row[i] if i < len(row) else ""
+            if value == "":
+                obj[header] = None
+            elif value.isdigit():
+                obj[header] = int(value)
+            else:
+                obj[header] = value
+        objects.append(obj)
+
+    return objects
 
 
 def write_efu(rows: List[List[str]], header_fields: List[str], file_path: str, newline: Optional[str] = None, encoding: str = 'utf-8') -> None:

--- a/tests/test_parse_efu_objects.py
+++ b/tests/test_parse_efu_objects.py
@@ -1,0 +1,43 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu_csv_utils import parse_efu_objects
+
+
+def test_parse_efu_objects(tmp_path):
+    csv_content = (
+        "Filename,Size,Date Modified,Date Created,Attributes\r\n"
+        "\"C:\\msys64\",,133876022280081366,133739602603410395,16\r\n"
+        "\"C:\\msys64\\autorebase.bat\",82,133262362720000000,133739602600000000,32\r\n"
+        "\"C:\\msys64\\clang64\",0,133665511886007850,133665511886007850,16\r\n"
+    )
+    sample_file = tmp_path / "sample.efu"
+    sample_file.write_text(csv_content, newline="")
+
+    objs = parse_efu_objects(str(sample_file))
+
+    assert objs == [
+        {
+            "Filename": "C:\\msys64",
+            "Size": None,
+            "Date Modified": 133876022280081366,
+            "Date Created": 133739602603410395,
+            "Attributes": 16,
+        },
+        {
+            "Filename": "C:\\msys64\\autorebase.bat",
+            "Size": 82,
+            "Date Modified": 133262362720000000,
+            "Date Created": 133739602600000000,
+            "Attributes": 32,
+        },
+        {
+            "Filename": "C:\\msys64\\clang64",
+            "Size": 0,
+            "Date Modified": 133665511886007850,
+            "Date Created": 133665511886007850,
+            "Attributes": 16,
+        },
+    ]


### PR DESCRIPTION
## Summary
- extend library with `parse_efu_objects` to convert EFU CSV rows into dictionaries
- document the new API in docs/README.md
- add pytest coverage for the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aed19b360832ba895ea4ed29a6199