### PR TITLE
Rename parse_efu_objects function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,10 +105,10 @@ def write_efu(
   * Fields with leading/trailing spaces are treated as text and quoted.
   * Zero-length value (`''`) always written as empty (no quotes): `, ,` yields `,,`.
 
-### 2.3 `parse_efu_objects`
+### 2.3 `efu_to_objects`
 
 ```python
-def parse_efu_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, Any]]
+def efu_to_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, Any]]
 ```
 
 * **Returns**: List of dictionaries using header names as keys. Empty fields become
@@ -144,7 +144,7 @@ write_efu(rows, header_fields, 'output.efu', newline=nl)
 ## 5. Limitations
 
 * `parse_efu` does not convert numeric strings to Python numeric types; use
-  `parse_efu_objects` for typed values.
+  `efu_to_objects` for typed values.
 * ISO/locale-specific encodings other than UTF-8 must be specified.
 * No streaming: entire file is loaded into memory; may not scale for extremely large EFU files.
 

--- a/src/efu_csv_utils/__init__.py
+++ b/src/efu_csv_utils/__init__.py
@@ -57,7 +57,7 @@ def parse_efu(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]],
     return rows, header_fields, newline
 
 
-def parse_efu_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, Any]]:
+def efu_to_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, Any]]:
     """Parse an EFU file and return a list of row dictionaries.
 
     Empty fields are converted to ``None`` and purely digit strings are

--- a/tests/test_efu_to_objects.py
+++ b/tests/test_efu_to_objects.py
@@ -3,10 +3,10 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
 
-from efu_csv_utils import parse_efu_objects
+from efu_csv_utils import efu_to_objects
 
 
-def test_parse_efu_objects(tmp_path):
+def test_efu_to_objects(tmp_path):
     csv_content = (
         "Filename,Size,Date Modified,Date Created,Attributes\r\n"
         "\"C:\\msys64\",,133876022280081366,133739602603410395,16\r\n"
@@ -16,7 +16,7 @@ def test_parse_efu_objects(tmp_path):
     sample_file = tmp_path / "sample.efu"
     sample_file.write_text(csv_content, newline="")
 
-    objs = parse_efu_objects(str(sample_file))
+    objs = efu_to_objects(str(sample_file))
 
     assert objs == [
         {


### PR DESCRIPTION
## Summary
- rename `parse_efu_objects` to `efu_to_objects`
- update docs to use the new name
- rename and update corresponding test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aef6960c8832bbd7830342ee9e950