### PR TITLE
Add objects_to_efu function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,30 @@ def efu_to_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, An
 * **Returns**: List of dictionaries using header names as keys. Empty fields become
   `None` and digit-only fields are converted to `int`.
 
+### 2.4 `objects_to_efu`
+
+```python
+def objects_to_efu(
+    objects: List[Dict[str, Any]],
+    file_path: str,
+    newline: Optional[str] = None,
+    encoding: str = 'utf-8'
+) -> None
+```
+
+* **Inputs**:
+
+  * `objects` (`List[Dict[str, Any]]`): Row dictionaries. ``None`` values become empty fields.
+  * `file_path` (`str`): Destination EFU file path.
+  * `newline` (`str`, optional): Newline sequence for data rows; default `'\n'`.
+  * `encoding` (`str`, optional): Text encoding (default `'utf-8'`).
+
+* **Behavior**:
+
+  1. Header fields are taken from the keys of the first object.
+  2. Values are converted to strings with ``str()`` (``None`` -> ``''``).
+  3. Delegates to `write_efu` for final serialization.
+
 ---
 
 ## 3. Examples

--- a/src/efu_csv_utils/__init__.py
+++ b/src/efu_csv_utils/__init__.py
@@ -82,6 +82,37 @@ def efu_to_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, An
     return objects
 
 
+def objects_to_efu(
+    objects: List[Dict[str, Any]],
+    file_path: str,
+    newline: Optional[str] = None,
+    encoding: str = 'utf-8',
+) -> None:
+    """Serialize a list of dictionaries to an EFU CSV file.
+
+    The header fields are derived from the keys of the first object and values
+    are converted to strings using ``str()``. ``None`` becomes an empty field.
+    The output formatting matches :func:`write_efu`.
+    """
+
+    if not objects:
+        raise ValueError("objects list must not be empty")
+
+    header_fields = list(objects[0].keys())
+    rows: List[List[str]] = []
+    for obj in objects:
+        row: List[str] = []
+        for key in header_fields:
+            value = obj.get(key)
+            if value is None:
+                row.append("")
+            else:
+                row.append(str(value))
+        rows.append(row)
+
+    write_efu(rows, header_fields, file_path, newline=newline, encoding=encoding)
+
+
 def write_efu(rows: List[List[str]], header_fields: List[str], file_path: str, newline: Optional[str] = None, encoding: str = 'utf-8') -> None:
     """
     Serialize rows to EFU file preserving newline style.

--- a/tests/test_objects_to_efu.py
+++ b/tests/test_objects_to_efu.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu_csv_utils import objects_to_efu
+
+
+def test_objects_to_efu(tmp_path):
+    objs = [
+        {
+            "Filename": "C:\\msys64",
+            "Size": None,
+            "Date Modified": 133876022280081366,
+            "Date Created": 133739602603410395,
+            "Attributes": 16,
+        },
+        {
+            "Filename": "C:\\msys64\\autorebase.bat",
+            "Size": 82,
+            "Date Modified": 133262362720000000,
+            "Date Created": 133739602600000000,
+            "Attributes": 32,
+        },
+        {
+            "Filename": "C:\\msys64\\clang64",
+            "Size": 0,
+            "Date Modified": 133665511886007850,
+            "Date Created": 133665511886007850,
+            "Attributes": 16,
+        },
+    ]
+
+    out_file = tmp_path / "out.efu"
+    objects_to_efu(objs, str(out_file), newline="\r\n")
+
+    expected = (
+        "Filename,Size,Date Modified,Date Created,Attributes\r\n"
+        "\"C:\\msys64\",,133876022280081366,133739602603410395,16\r\n"
+        "\"C:\\msys64\\autorebase.bat\",82,133262362720000000,133739602600000000,32\r\n"
+        "\"C:\\msys64\\clang64\",0,133665511886007850,133665511886007850,16\r\n"
+    )
+
+    with open(out_file, "r", newline="") as f:
+        content = f.read()
+    assert content == expected


### PR DESCRIPTION
## Summary
- add `objects_to_efu` function for converting object arrays to EFU CSV
- document new function in API docs
- test objects_to_efu behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af13418ac832b84bbb3bca0973b50