### PR TITLE
Add httpimport remote import test

### DIFF
--- a/tests/test_httpimport_remote.py
+++ b/tests/test_httpimport_remote.py
@@ -1,0 +1,10 @@
+import importlib
+import httpimport
+
+
+def test_import_remote_efu_csv_utils():
+    url = 'https://raw.githubusercontent.com/TakashiSasaki/efu/refs/heads/main/src/'
+    with httpimport.remote_repo(url=url):
+        module = importlib.import_module('efu_csv_utils')
+        assert hasattr(module, '__version__')
+        assert module.__version__ == '0.1.0'


### PR DESCRIPTION
## Summary
- add a test to ensure `efu_csv_utils` can be imported remotely via `httpimport`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af4a6b0dc832b96d2bab61fc602f4