### PR TITLE
Add remote import guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Utilities for parsing and writing Everything EFU CSV files.
 
-This package provides helper functions for losslessly converting between
-Everything's EFU CSV format and Python objects. It preserves the original
-newline style and quoting rules so that files can be parsed and written back
-verbatim. A small CLI is included for round‐trip verification.
+This package provides helper functions for losslessly converting between Everything's EFU CSV format and Python objects. It preserves the original newline style and quoting rules so that files can be parsed and written back verbatim. A small CLI is included for round‐trip verification.
 
-See [docs/README.md](docs/README.md) for the full design specification.
+## Documentation
+
+- [Specification](docs/README.md)
+- [Time Columns](docs/filetime.md)
+- [Attribute Flags](docs/attribute-flags.md)
+- [JSON Example](docs/json.md)
+- [Remote Import Guide](docs/REMOTE.md)
+
 Additional documentation resides in the `docs` directory.

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -1,0 +1,48 @@
+# REMOTE Import Usage Guide
+
+This document explains how to import the `efu_csv_utils` package directly from the remote repository using the `httpimport` package. This approach allows you to use the library without installing it locally.
+
+---
+
+## Requirements
+
+- Python 3.10 or newer
+- The [`httpimport`](https://pypi.org/project/httpimport/) package
+
+Install `httpimport` with pip if you don't already have it:
+
+```bash
+pip install httpimport
+```
+
+## Basic Usage
+
+1. Define the URL to the directory containing `efu_csv_utils` on GitHub:
+
+```python
+REMOTE_URL = "https://raw.githubusercontent.com/TakashiSasaki/efu/refs/heads/main/src/"
+```
+
+2. Use `httpimport.remote_repo` as a context manager and import `efu_csv_utils`:
+
+```python
+import importlib
+import httpimport
+
+with httpimport.remote_repo(url=REMOTE_URL):
+    efu_csv_utils = importlib.import_module("efu_csv_utils")
+```
+
+3. Call functions from the imported module as usual:
+
+```python
+rows, header_fields, nl = efu_csv_utils.parse_efu("sample.efu")
+```
+
+## Notes
+
+- The files are downloaded temporarily each time the context manager is entered.
+- A network connection to GitHub is required while importing.
+- This method mirrors the approach used in the test suite (`tests/test_httpimport_*.py`).
+
+*End of REMOTE import guide*


### PR DESCRIPTION
## Summary
- add REMOTE.md documenting httpimport usage for remote imports
- update README with documentation table of contents

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b27ce5ba4832baad723e9a0b4bdb6