### PR TITLE
Rename parsing utilities

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,10 +19,10 @@ This document describes the design, behavior, and API of the `efu_csv_utils.py` 
 
 ## 2. API
 
-### 2.1 `parse_efu`
+### 2.1 `efu_to_array`
 
 ```python
-def parse_efu(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]], str, str]
+def efu_to_array(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]], str, str]
 ```
 
 * **Inputs**:
@@ -55,10 +55,10 @@ def parse_efu(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]],
   * Lines with consecutive commas produce empty-string fields (`''`).
   * Fields containing commas or quotes must be quoted and escaped in source; parser handles that.
 
-### 2.2 `write_efu`
+### 2.2 `array_to_efu`
 
 ```python
-def write_efu(
+def array_to_efu(
     rows: List[List[str]],
     header_fields: List[str],
     file_path: str,
@@ -69,7 +69,7 @@ def write_efu(
 
 * **Inputs**:
 
-  * `rows` (`List[List[str]]`): Data rows (from `parse_efu`), each a list of field strings.
+  * `rows` (`List[List[str]]`): Data rows (from `efu_to_array`), each a list of field strings.
   * `header_fields` (`List[str]`): Header row values split on commas.
   * `file_path` (`str`): Destination path for the output EFU file.
   * `newline` (`str`, optional): Newline sequence to use for data rows; defaults to `'\n'` if not provided.
@@ -136,7 +136,7 @@ def objects_to_efu(
 
   1. Header fields are taken from the keys of the first object.
   2. Values are converted to strings with ``str()`` (``None`` -> ``''``).
-  3. Delegates to `write_efu` for final serialization.
+  3. Delegates to `array_to_efu` for final serialization.
 
 ---
 
@@ -151,8 +151,8 @@ Filename,Size,Date Modified,Date Created,Attributes\r\n
 ```
 
 ```python
-rows, header_fields, nl = parse_efu('input.efu')
-write_efu(rows, header_fields, 'output.efu', newline=nl)
+rows, header_fields, nl = efu_to_array('input.efu')
+array_to_efu(rows, header_fields, 'output.efu', newline=nl)
 # 'output.efu' is now byte-for-byte identical to 'input.efu'
 ```
 
@@ -167,7 +167,7 @@ write_efu(rows, header_fields, 'output.efu', newline=nl)
 
 ## 5. Limitations
 
-* `parse_efu` does not convert numeric strings to Python numeric types; use
+* `efu_to_array` does not convert numeric strings to Python numeric types; use
   `efu_to_objects` for typed values.
 * ISO/locale-specific encodings other than UTF-8 must be specified.
 * No streaming: entire file is loaded into memory; may not scale for extremely large EFU files.

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -36,7 +36,7 @@ with httpimport.remote_repo(url=REMOTE_URL):
 3. Call functions from the imported module as usual:
 
 ```python
-rows, header_fields, nl = efu_csv_utils.parse_efu("sample.efu")
+rows, header_fields, nl = efu_csv_utils.efu_to_array("sample.efu")
 ```
 
 ## Notes

--- a/src/efu_csv_utils/__init__.py
+++ b/src/efu_csv_utils/__init__.py
@@ -11,7 +11,7 @@ __version__ = "0.1.0"
 from typing import Any, Dict, List, Optional, Tuple
 
 
-def parse_efu(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]], List[str], str]:
+def efu_to_array(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]], List[str], str]:
     """
     Parse an Everything EFU (CSV) file into a list of rows (excluding header),
     returning rows, the header fields as a list of strings, and detected newline style.
@@ -71,7 +71,7 @@ def efu_to_objects(file_path: str, encoding: str = 'utf-8') -> List[Dict[str, An
     converted to ``int``. Keys are taken from the header row.
     """
 
-    rows, header_fields, _ = parse_efu(file_path, encoding=encoding)
+    rows, header_fields, _ = efu_to_array(file_path, encoding=encoding)
 
     objects: List[Dict[str, Any]] = []
     for row in rows:
@@ -99,7 +99,7 @@ def objects_to_efu(
 
     The header fields are derived from the keys of the first object and values
     are converted to strings using ``str()``. ``None`` becomes an empty field.
-    The output formatting matches :func:`write_efu`.
+    The output formatting matches :func:`array_to_efu`.
     """
 
     if not objects:
@@ -117,10 +117,10 @@ def objects_to_efu(
                 row.append(str(value))
         rows.append(row)
 
-    write_efu(rows, header_fields, file_path, newline=newline, encoding=encoding)
+    array_to_efu(rows, header_fields, file_path, newline=newline, encoding=encoding)
 
 
-def write_efu(rows: List[List[str]], header_fields: List[str], file_path: str, newline: Optional[str] = None, encoding: str = 'utf-8') -> None:
+def array_to_efu(rows: List[List[str]], header_fields: List[str], file_path: str, newline: Optional[str] = None, encoding: str = 'utf-8') -> None:
     """
     Serialize rows to EFU file preserving newline style.
     The header is supplied as a list of strings which will be joined with commas
@@ -159,8 +159,8 @@ def main(argv: Optional[List[str]] = None) -> None:
     parser.add_argument("output", help="Path to write the output EFU file")
     args = parser.parse_args(argv)
 
-    rows, header_fields, nl = parse_efu(args.input)
-    write_efu(rows, header_fields, args.output, newline=nl)
+    rows, header_fields, nl = efu_to_array(args.input)
+    array_to_efu(rows, header_fields, args.output, newline=nl)
 
     # Verify round-trip
     with open(args.input, "rb") as f:

--- a/tests/test_httpimport_functions.py
+++ b/tests/test_httpimport_functions.py
@@ -13,7 +13,7 @@ def remote_efu():
 
 
 def test_parse_efu_simple_remote(tmp_path, remote_efu):
-    parse_efu = remote_efu.parse_efu
+    parse_efu = remote_efu.efu_to_array
 
     csv_content = (
         "Filename,Size,Date Modified,Date Created,Attributes\r\n"
@@ -55,7 +55,7 @@ def test_parse_efu_simple_remote(tmp_path, remote_efu):
 
 
 def test_write_efu_simple_remote(tmp_path, remote_efu):
-    write_efu = remote_efu.write_efu
+    write_efu = remote_efu.array_to_efu
 
     header = [
         'Filename',
@@ -179,8 +179,8 @@ def test_efu_to_objects_remote(tmp_path, remote_efu):
 
 
 def test_roundtrip_remote(tmp_path, remote_efu):
-    parse_efu = remote_efu.parse_efu
-    write_efu = remote_efu.write_efu
+    parse_efu = remote_efu.efu_to_array
+    write_efu = remote_efu.array_to_efu
     root = pathlib.Path(__file__).resolve().parents[1]
     sample = root / 'samples' / 'sample1.efu'
 

--- a/tests/test_parse_efu.py
+++ b/tests/test_parse_efu.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
 
-from efu_csv_utils import parse_efu
+from efu_csv_utils import efu_to_array
 
 
 def test_parse_efu_simple(tmp_path):
@@ -17,7 +17,7 @@ def test_parse_efu_simple(tmp_path):
     sample_file = tmp_path / "sample.efu"
     sample_file.write_text(csv_content, newline="")
 
-    rows, header, nl = parse_efu(str(sample_file))
+    rows, header, nl = efu_to_array(str(sample_file))
 
     assert header == [
         "Filename",

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -4,16 +4,16 @@ import sys
 # Add package source to path
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
 
-from efu_csv_utils import parse_efu, write_efu
+from efu_csv_utils import efu_to_array, array_to_efu
 
 
 def test_roundtrip(tmp_path):
     root = pathlib.Path(__file__).resolve().parents[1]
     sample = root / 'samples' / 'sample1.efu'
 
-    rows, header_fields, nl = parse_efu(str(sample))
+    rows, header_fields, nl = efu_to_array(str(sample))
     out_file = tmp_path / 'out.efu'
-    write_efu(rows, header_fields, str(out_file), newline=nl)
+    array_to_efu(rows, header_fields, str(out_file), newline=nl)
 
     with open(sample, 'rb') as f:
         original = f.read()

--- a/tests/test_write_efu.py
+++ b/tests/test_write_efu.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
 
-from efu_csv_utils import write_efu
+from efu_csv_utils import array_to_efu
 
 
 def test_write_efu_simple(tmp_path):
@@ -33,7 +33,7 @@ def test_write_efu_simple(tmp_path):
     ]
 
     out_file = tmp_path / "out.efu"
-    write_efu(rows, header, str(out_file), newline="\r\n")
+    array_to_efu(rows, header, str(out_file), newline="\r\n")
 
     expected = (
         "Filename,Size,Date Modified,Date Created,Attributes\r\n"


### PR DESCRIPTION
## Summary
- rename `parse_efu` -> `efu_to_array`
- rename `write_efu` -> `array_to_efu`
- update docs and tests for new names

## Testing
- `pip install httpimport`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2876d8b4832b9ac0ac0e3e5861b7