### PR TITLE
Implement EfuRecord class

### DIFF
--- a/src/efu/__init__.py
+++ b/src/efu/__init__.py
@@ -8,7 +8,46 @@ identical to the original.
 
 __version__ = "0.1.0"
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+
+class EfuRecord(dict):
+    """Dictionary-like record initialized with EFU header fields.
+
+    Parameters
+    ----------
+    headers:
+        Iterable of header field names. An entry is created for each key
+        with the value ``None`` by default.
+    data:
+        Optional mapping of initial values which are applied after the
+        default keys are created.
+    last_seen, first_seen, last_lost:
+        Optional Windows FILETIME integers associated with the record.
+    **kwargs:
+        Additional key/value pairs to update the record with.
+    """
+
+    __slots__ = ("last_seen", "first_seen", "last_lost")
+
+    def __init__(
+        self,
+        headers: Iterable[str],
+        data: Optional[Mapping[str, Any]] = None,
+        *,
+        last_seen: int = 0,
+        first_seen: int = 0,
+        last_lost: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__({key: None for key in headers})
+        if data:
+            self.update(data)
+        if kwargs:
+            self.update(kwargs)
+        self.last_seen = last_seen
+        self.first_seen = first_seen
+        self.last_lost = last_lost
 
 
 def efu_to_array(file_path: str, encoding: str = 'utf-8') -> Tuple[List[List[str]], List[str], str]:

--- a/tests/test_efu_record.py
+++ b/tests/test_efu_record.py
@@ -1,0 +1,47 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu import EfuRecord
+
+
+def test_efu_record_initialization():
+    header = [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+    rec = EfuRecord(header)
+    assert list(rec.keys()) == header
+    assert all(value is None for value in rec.values())
+
+
+def test_efu_record_with_data():
+    header = [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+    rec = EfuRecord(header, {"Filename": "foo"}, Size=100)
+    assert rec["Filename"] == "foo"
+    assert rec["Size"] == 100
+    for key in header:
+        assert key in rec
+
+
+def test_efu_record_attributes():
+    header = ["Filename"]
+    rec = EfuRecord(header)
+    assert rec.last_seen == 0
+    assert rec.first_seen == 0
+    assert rec.last_lost == 0
+
+    rec2 = EfuRecord(header, last_seen=1, first_seen=2, last_lost=3)
+    assert rec2.last_seen == 1
+    assert rec2.first_seen == 2
+    assert rec2.last_lost == 3

--- a/tests/test_httpimport_functions.py
+++ b/tests/test_httpimport_functions.py
@@ -8,7 +8,7 @@ REMOTE_URL = 'https://raw.githubusercontent.com/TakashiSasaki/efu/refs/heads/mai
 @pytest.fixture(scope='session')
 def remote_efu():
     with httpimport.remote_repo(url=REMOTE_URL):
-        module = importlib.import_module('efu_csv_utils')
+        module = importlib.import_module('efu')
     return module
 
 

--- a/tests/test_httpimport_remote.py
+++ b/tests/test_httpimport_remote.py
@@ -2,9 +2,9 @@ import importlib
 import httpimport
 
 
-def test_import_remote_efu_csv_utils():
+def test_import_remote_efu_module():
     url = 'https://raw.githubusercontent.com/TakashiSasaki/efu/refs/heads/main/src/'
     with httpimport.remote_repo(url=url):
-        module = importlib.import_module('efu_csv_utils')
+        module = importlib.import_module('efu')
         assert hasattr(module, '__version__')
         assert module.__version__ == '0.1.0'


### PR DESCRIPTION
## Summary
- add `EfuRecord` that initializes keys from EFU headers with `None`
- store FILETIME fields (`last_seen`, `first_seen`, `last_lost`) and declare `__slots__`
- test `EfuRecord`
- update httpimport tests to import the renamed `efu` module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b2ee9b730832b81799b700925a2fe