### PR TITLE
Add root property to EfuRecord

### DIFF
--- a/src/efu/efu_record.py
+++ b/src/efu/efu_record.py
@@ -1,10 +1,10 @@
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, Union
 
 
 class EfuRecord(dict):
     """Dictionary-like record initialized with EFU header fields."""
 
-    __slots__ = ("last_seen", "first_seen", "last_lost")
+    __slots__ = ("last_seen", "first_seen", "last_lost", "root")
 
     def __init__(
         self,
@@ -14,6 +14,7 @@ class EfuRecord(dict):
         last_seen: int = 0,
         first_seen: int = 0,
         last_lost: int = 0,
+        root: Optional[Union[str, int]] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__({key: None for key in headers})
@@ -24,3 +25,4 @@ class EfuRecord(dict):
         self.last_seen = last_seen
         self.first_seen = first_seen
         self.last_lost = last_lost
+        self.root = root

--- a/tests/test_efu_record.py
+++ b/tests/test_efu_record.py
@@ -40,8 +40,13 @@ def test_efu_record_attributes():
     assert rec.last_seen == 0
     assert rec.first_seen == 0
     assert rec.last_lost == 0
+    assert rec.root is None
 
-    rec2 = EfuRecord(header, last_seen=1, first_seen=2, last_lost=3)
+    rec2 = EfuRecord(header, last_seen=1, first_seen=2, last_lost=3, root="foo")
     assert rec2.last_seen == 1
     assert rec2.first_seen == 2
     assert rec2.last_lost == 3
+    assert rec2.root == "foo"
+
+    rec3 = EfuRecord(header, root=10)
+    assert rec3.root == 10


### PR DESCRIPTION
## Summary
- extend `EfuRecord` with `root` attribute
- test default, string and integer root values

## Testing
- `pip install httpimport`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b345588b0832b8194d0d9b262720c