### PR TITLE
Add EfuRecords container class

### DIFF
--- a/src/efu/__init__.py
+++ b/src/efu/__init__.py
@@ -9,6 +9,7 @@ identical to the original.
 __version__ = "0.1.1"
 
 from .efu_record import EfuRecord
+from .efu_records import EfuRecords
 from .efu_to_array import efu_to_array
 from .efu_to_objects import efu_to_objects
 from .objects_to_efu import objects_to_efu
@@ -17,6 +18,7 @@ from .cli import main
 
 __all__ = [
     "EfuRecord",
+    "EfuRecords",
     "efu_to_array",
     "efu_to_objects",
     "array_to_efu",

--- a/src/efu/efu_records.py
+++ b/src/efu/efu_records.py
@@ -1,0 +1,17 @@
+from typing import Iterable
+from collections import UserList
+
+from .efu_record import EfuRecord
+
+
+class EfuRecords(UserList[EfuRecord]):
+    """List-like collection for :class:`EfuRecord` objects."""
+
+    def __init__(self, records: Iterable[EfuRecord] = ()) -> None:
+        super().__init__(list(records))
+
+    def append_from_path(self, file_path: str, headers: Iterable[str]) -> None:
+        """Create an :class:`EfuRecord` from ``file_path`` and append it."""
+        record = EfuRecord(headers)
+        record.populate_from_path(file_path)
+        self.append(record)

--- a/tests/test_efu_records.py
+++ b/tests/test_efu_records.py
@@ -1,0 +1,51 @@
+import pathlib
+import sys
+import os
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu import EfuRecord, EfuRecords
+
+
+def test_efu_records_basic():
+    header = [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+    rec1 = EfuRecord(header, {"Filename": "foo"}, Size=1)
+    rec2 = EfuRecord(header, {"Filename": "bar"}, Size=2)
+    records = EfuRecords([rec1, rec2])
+
+    assert len(records) == 2
+    assert records[0]["Filename"] == "foo"
+    assert records[1]["Size"] == 2
+
+
+def test_append_from_path(tmp_path):
+    header = [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+    sample = tmp_path / "file.txt"
+    sample.write_text("hello")
+
+    records = EfuRecords()
+    records.append_from_path(str(sample), header)
+
+    assert len(records) == 1
+    rec = records[0]
+    st = os.stat(sample)
+    expected_modified = int(st.st_mtime * 10_000_000) + 116444736000000000
+    expected_created = int(st.st_ctime * 10_000_000) + 116444736000000000
+
+    assert rec["Filename"] == str(sample)
+    assert rec["Size"] == st.st_size
+    assert rec["Date Modified"] == expected_modified
+    assert rec["Date Created"] == expected_created
+    assert rec["Attributes"] == 32


### PR DESCRIPTION
## Summary
- add `EfuRecords` class for managing lists of `EfuRecord`
- export new class in `efu.__init__`
- test `EfuRecords` basic behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b35758bd0832b8139b8ac50c5d501