### PR TITLE
Add recursive directory record function

### DIFF
--- a/src/efu/efu_records.py
+++ b/src/efu/efu_records.py
@@ -1,5 +1,6 @@
 from typing import Iterable
 from collections import UserList
+import os
 
 from .efu_record import EfuRecord
 
@@ -15,3 +16,10 @@ class EfuRecords(UserList[EfuRecord]):
         record = EfuRecord(headers)
         record.populate_from_path(file_path)
         self.append(record)
+
+    def extend_from_directory(self, dir_path: str, headers: Iterable[str]) -> None:
+        """Recursively append records for all entries under ``dir_path``."""
+        for root, dirs, files in os.walk(dir_path):
+            self.append_from_path(root, headers)
+            for name in files:
+                self.append_from_path(os.path.join(root, name), headers)

--- a/tests/test_efu_records.py
+++ b/tests/test_efu_records.py
@@ -49,3 +49,47 @@ def test_append_from_path(tmp_path):
     assert rec["Date Modified"] == expected_modified
     assert rec["Date Created"] == expected_created
     assert rec["Attributes"] == 32
+
+
+def test_extend_from_directory(tmp_path):
+    header = [
+        "Filename",
+        "Size",
+        "Date Modified",
+        "Date Created",
+        "Attributes",
+    ]
+
+    dir1 = tmp_path / "dir1"
+    dir1.mkdir()
+    file1 = dir1 / "file1.txt"
+    file1.write_text("a")
+
+    dir2 = tmp_path / "dir2"
+    dir2.mkdir()
+    file2 = dir2 / "file2.txt"
+    file2.write_text("b")
+
+    records = EfuRecords()
+    records.extend_from_directory(str(tmp_path), header)
+
+    expected_paths = {
+        str(tmp_path),
+        str(dir1),
+        str(file1),
+        str(dir2),
+        str(file2),
+    }
+
+    filenames = {rec["Filename"] for rec in records}
+    assert filenames == expected_paths
+    assert len(records) == len(expected_paths)
+
+    rec_file1 = next(r for r in records if r["Filename"] == str(file1))
+    st_file1 = os.stat(file1)
+    expected_modified = int(st_file1.st_mtime * 10_000_000) + 116444736000000000
+    expected_created = int(st_file1.st_ctime * 10_000_000) + 116444736000000000
+    assert rec_file1["Size"] == st_file1.st_size
+    assert rec_file1["Date Modified"] == expected_modified
+    assert rec_file1["Date Created"] == expected_created
+    assert rec_file1["Attributes"] == 32


### PR DESCRIPTION
## Summary
- expand `EfuRecords` with a method to append entries from a directory tree
- test recursive directory collection

## Testing
- `pip install httpimport`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3b37e4d4832b935f7fe260032974