### PR TITLE
Allow None defaults for date fields

### DIFF
--- a/src/efu/efu_record.py
+++ b/src/efu/efu_record.py
@@ -21,9 +21,9 @@ class EfuRecord(dict):
         headers: Iterable[str],
         data: Optional[Mapping[str, Any]] = None,
         *,
-        last_seen: int = 0,
-        first_seen: int = 0,
-        last_lost: int = 0,
+        last_seen: Optional[int] = None,
+        first_seen: Optional[int] = None,
+        last_lost: Optional[int] = None,
         root: Optional[Union[str, int]] = None,
         **kwargs: Any,
     ) -> None:

--- a/tests/test_efu_record.py
+++ b/tests/test_efu_record.py
@@ -38,9 +38,9 @@ def test_efu_record_with_data():
 def test_efu_record_attributes():
     header = ["Filename"]
     rec = EfuRecord(header)
-    assert rec.last_seen == 0
-    assert rec.first_seen == 0
-    assert rec.last_lost == 0
+    assert rec.last_seen is None
+    assert rec.first_seen is None
+    assert rec.last_lost is None
     assert rec.root is None
 
     rec2 = EfuRecord(header, last_seen=1, first_seen=2, last_lost=3, root="foo")


### PR DESCRIPTION
## Summary
- allow `None` defaults for `last_seen`, `first_seen`, `last_lost`
- update tests for new defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b3bc407fc832b9538d9b6a11dcab0