### PR TITLE
Add type checks for EfuRecord values

### DIFF
--- a/tests/test_efu_records.py
+++ b/tests/test_efu_records.py
@@ -114,3 +114,10 @@ def test_extend_repository_root():
     assert str(root / "pyproject.toml") in filenames
     assert len(records) >= 3
 
+    for rec in records:
+        assert isinstance(rec["Filename"], str)
+        assert isinstance(rec["Size"], int)
+        assert isinstance(rec["Date Modified"], int)
+        assert isinstance(rec["Date Created"], int)
+        assert isinstance(rec["Attributes"], int)
+


### PR DESCRIPTION
## Summary
- verify that each EfuRecord value is of the expected type in `test_extend_repository_root`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3e8f492c832bb1f0a397fceee260