### PR TITLE
Add Root class with hostname logic

### DIFF
--- a/src/efu/__init__.py
+++ b/src/efu/__init__.py
@@ -15,6 +15,7 @@ from .efu_to_objects import efu_to_objects
 from .objects_to_efu import objects_to_efu
 from .array_to_efu import array_to_efu
 from .cli import main
+from .root import Root
 
 __all__ = [
     "EfuRecord",
@@ -24,4 +25,5 @@ __all__ = [
     "array_to_efu",
     "objects_to_efu",
     "main",
+    "Root",
 ]

--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -1,0 +1,29 @@
+import socket
+import json
+import hashlib
+import base64
+from typing import Any
+
+
+class Root:
+    """Represent host information for EFU records."""
+
+    def __init__(self) -> None:
+        try:
+            hostname = socket.gethostname()
+        except Exception as e:
+            raise RuntimeError("Unable to obtain hostname") from e
+        if not hostname:
+            raise RuntimeError("Hostname could not be determined")
+        self.hostname = hostname
+
+    @staticmethod
+    def canonical_hash(data: Any) -> str:
+        """Return first 10 chars of base64url SHA1 of canonical JSON of ``data``."""
+        json_str = json.dumps(data, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+        digest = hashlib.sha1(json_str.encode("utf-8")).digest()
+        b64 = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+        return b64[:10]
+
+    def __str__(self) -> str:
+        return self.hostname

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+import socket
+import json
+import hashlib
+import base64
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu.root import Root
+
+
+def test_root_initialization():
+    root = Root()
+    assert root.hostname == socket.gethostname()
+
+
+def test_canonical_hash():
+    data = {"b": 2, "a": 1}
+    h = Root.canonical_hash(data)
+
+    json_str = json.dumps(data, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    digest = hashlib.sha1(json_str.encode('utf-8')).digest()
+    expected = base64.urlsafe_b64encode(digest).decode('ascii').rstrip('=')[:10]
+    assert h == expected


### PR DESCRIPTION
## Summary
- implement `Root` class to hold hostname and compute canonical hashes
- expose `Root` in package exports
- test `Root` class behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b533593f8832baea6336148a53c8e