### PR TITLE
Implement Root class with host info

### DIFF
--- a/src/efu/__init__.py
+++ b/src/efu/__init__.py
@@ -15,6 +15,7 @@ from .efu_to_objects import efu_to_objects
 from .objects_to_efu import objects_to_efu
 from .array_to_efu import array_to_efu
 from .cli import main
+from .root import Root
 
 __all__ = [
     "EfuRecord",
@@ -23,5 +24,6 @@ __all__ = [
     "efu_to_objects",
     "array_to_efu",
     "objects_to_efu",
+    "Root",
     "main",
 ]

--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -1,0 +1,47 @@
+import os
+import socket
+import uuid
+from typing import Optional
+
+
+class Root:
+    """Information about a machine and path."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self.hostname: Optional[str] = None
+        self.mac_address: Optional[str] = None
+        self.ip_address: Optional[str] = None
+        self.path: Optional[str] = None
+
+        try:
+            self.hostname = socket.gethostname()
+        except Exception:
+            self.hostname = None
+
+        try:
+            node = uuid.getnode()
+            self.mac_address = ":".join(
+                f"{(node >> i) & 0xFF:02x}" for i in range(40, -1, -8)
+            )
+        except Exception:
+            self.mac_address = None
+
+        try:
+            if self.hostname:
+                self.ip_address = socket.gethostbyname(self.hostname)
+            else:
+                self.ip_address = None
+        except Exception:
+            self.ip_address = None
+
+        if path is not None:
+            try:
+                self.path = os.fspath(path)
+            except Exception:
+                self.path = None
+        else:
+            try:
+                self.path = os.getcwd()
+            except Exception:
+                self.path = None
+

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+import socket
+import uuid
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu import Root
+
+
+def test_root_basic(tmp_path):
+    r = Root(str(tmp_path))
+    assert r.path == str(tmp_path)
+    assert r.hostname is None or isinstance(r.hostname, str)
+    assert r.ip_address is None or isinstance(r.ip_address, str)
+    assert r.mac_address is None or isinstance(r.mac_address, str)
+
+
+def test_hostname_failure(monkeypatch):
+    def bad_hostname():
+        raise OSError('fail')
+
+    monkeypatch.setattr(socket, 'gethostname', bad_hostname)
+    monkeypatch.setattr(socket, 'gethostbyname', lambda x: (_ for _ in ()).throw(RuntimeError('should not be called')))
+    monkeypatch.setattr(uuid, 'getnode', lambda: 0x010203040506)
+
+    r = Root('/tmp')
+    assert r.hostname is None
+    assert r.ip_address is None
+    assert r.mac_address == '01:02:03:04:05:06'


### PR DESCRIPTION
## Summary
- add `Root` class with hostname, MAC address, IP address and path info
- expose `Root` in package exports
- test `Root` basic usage and hostname failure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b54c5eebc832bb16c8e2d7aad2777