### PR TITLE
Fix default Root.path to use absolute CWD

### DIFF
--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -44,7 +44,7 @@ class Root:
                 self.path = None
         else:
             try:
-                self.path = os.getcwd()
+                self.path = os.path.abspath(os.getcwd())
             except Exception:
                 self.path = None
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -5,6 +5,7 @@ import base64
 import json
 import uuid
 import hashlib
+import os
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
 
@@ -34,6 +35,12 @@ def test_hostname_failure(monkeypatch):
 def test_root_initialization():
     root = Root()
     assert root.hostname == socket.gethostname()
+
+
+def test_root_default_path():
+    expected = os.path.abspath(os.getcwd())
+    root = Root()
+    assert root.path == expected
 
 
 def test_canonical_hash():


### PR DESCRIPTION
## Summary
- ensure Root uses an absolute path when no path argument is given
- test that Root defaults to the current working directory's full path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b58cc2084832b8d854a1c8034e42d