### PR TITLE
Normalize JSON with jcs before hashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ packages = [{include = "efu", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8"
+jcs = "^0.2"
 
 [tool.poetry.scripts]
 efu = "efu:main"

--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -3,6 +3,7 @@ import socket
 import uuid
 from typing import Optional, Any
 import json
+import jcs
 import hashlib
 import base64
 
@@ -51,8 +52,9 @@ class Root:
     @staticmethod
     def canonical_hash(data: Any) -> str:
         """Return first 10 chars of base64url SHA1 of canonical JSON of ``data``."""
-        json_str = json.dumps(data, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
-        digest = hashlib.sha1(json_str.encode("utf-8")).digest()
+        json_bytes = jcs.canonicalize(data)
+        json_str = json_bytes.decode("utf-8")
+        digest = hashlib.sha1(json_bytes).digest()
         b64 = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
         return b64[:10]
 

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -3,6 +3,7 @@ import sys
 import socket
 import base64
 import json
+import jcs
 import uuid
 import hashlib
 import os
@@ -47,7 +48,7 @@ def test_canonical_hash():
     data = {"b": 2, "a": 1}
     h = Root.canonical_hash(data)
 
-    json_str = json.dumps(data, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
-    digest = hashlib.sha1(json_str.encode('utf-8')).digest()
+    json_bytes = jcs.canonicalize(data)
+    digest = hashlib.sha1(json_bytes).digest()
     expected = base64.urlsafe_b64encode(digest).decode('ascii').rstrip('=')[:10]
     assert h == expected


### PR DESCRIPTION
## Summary
- include `jcs` as a dependency
- normalize JSON via `jcs.canonicalize` inside `Root.canonical_hash`
- adapt tests to use `jcs` canonicalization

## Testing
- `pip install jcs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5e6c820c832bae2ebce79e2a9bbd