### PR TITLE
Fix CI dev dependency installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ packages = [{include = "efu", from = "src"}]
 python = "^3.8"
 jcs = "^0.2"
 
+[tool.poetry.group.dev.dependencies]
+flake8 = {version = "^6.0", python = ">=3.8.1"}
+pytest = "^8.0"
+httpimport = "^1.4"
+
 [tool.poetry.scripts]
 efu = "efu:main"
 


### PR DESCRIPTION
## Summary
- add `tool.poetry.group.dev.dependencies` to declare development packages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b637666dc832b9041a905fdad31fa