### PR TITLE
Add Root JSON output and CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ httpimport = "^1.4"
 
 [tool.poetry.scripts]
 efu = "efu:main"
+efu_root = "efu.root_cli:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/efu/__init__.py
+++ b/src/efu/__init__.py
@@ -15,6 +15,7 @@ from .efu_to_objects import efu_to_objects
 from .objects_to_efu import objects_to_efu
 from .array_to_efu import array_to_efu
 from .cli import main
+from .root_cli import main as root_main
 from .root import Root
 
 __all__ = [
@@ -26,5 +27,6 @@ __all__ = [
     "objects_to_efu",
     "Root",
     "main",
+    "root_main",
     "Root",
 ]

--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -53,10 +53,26 @@ class Root:
     def canonical_hash(data: Any) -> str:
         """Return first 10 chars of base64url SHA1 of canonical JSON of ``data``."""
         json_bytes = jcs.canonicalize(data)
-        json_str = json_bytes.decode("utf-8")
         digest = hashlib.sha1(json_bytes).digest()
         b64 = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
         return b64[:10]
 
+    def to_json(self) -> str:
+        """Return canonical JSON string of this instance."""
+        data = {
+            "hostname": self.hostname,
+            "ip_address": self.ip_address,
+            "mac_address": self.mac_address,
+            "path": self.path,
+        }
+        return jcs.canonicalize(data).decode("utf-8")
+
     def __str__(self) -> str:
-        return self.hostname
+        """Return human readable JSON representation of this instance."""
+        data = {
+            "hostname": self.hostname,
+            "ip_address": self.ip_address,
+            "mac_address": self.mac_address,
+            "path": self.path,
+        }
+        return json.dumps(data, ensure_ascii=False, indent=2)

--- a/src/efu/root_cli.py
+++ b/src/efu/root_cli.py
@@ -1,0 +1,21 @@
+from typing import Optional, List
+
+from .root import Root
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """Command line interface for displaying Root information."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Show Root information")
+    parser.add_argument("path", nargs="?", help="Optional path", default=None)
+    parser.add_argument(
+        "--json", action="store_true", help="Output canonical JSON"
+    )
+    args = parser.parse_args(argv)
+
+    root = Root(args.path)
+    if args.json:
+        print(root.to_json())
+    else:
+        print(str(root))

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -52,3 +52,18 @@ def test_canonical_hash():
     digest = hashlib.sha1(json_bytes).digest()
     expected = base64.urlsafe_b64encode(digest).decode('ascii').rstrip('=')[:10]
     assert h == expected
+
+
+def test_to_json(tmp_path):
+    r = Root(str(tmp_path))
+    js = r.to_json()
+    data = json.loads(js)
+    assert data['path'] == str(tmp_path)
+    assert js == jcs.canonicalize(data).decode('utf-8')
+
+
+def test_str(tmp_path):
+    r = Root(str(tmp_path))
+    s = str(r)
+    data = json.loads(s)
+    assert data['path'] == str(tmp_path)

--- a/tests/test_root_cli.py
+++ b/tests/test_root_cli.py
@@ -1,0 +1,21 @@
+import pathlib
+import sys
+import json
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from efu.root_cli import main as root_main
+
+
+def test_root_cli_json(tmp_path, capsys):
+    root_main([str(tmp_path), '--json'])
+    out = capsys.readouterr().out.strip()
+    data = json.loads(out)
+    assert data['path'] == str(tmp_path)
+
+
+def test_root_cli_default(tmp_path, capsys):
+    root_main([str(tmp_path)])
+    out = capsys.readouterr().out.strip()
+    data = json.loads(out)
+    assert data['path'] == str(tmp_path)


### PR DESCRIPTION
## Summary
- enhance `Root` with `to_json()` and improved `__str__`
- expose `root_main` and entrypoint for a new CLI tool
- implement the CLI in `root_cli.py`
- test the new JSON methods and CLI usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b65a990ec832babd0376f2f7fabd0