### PR TITLE
Fix loopback IP detection

### DIFF
--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -6,6 +6,7 @@ import json
 import jcs
 import hashlib
 import base64
+import ipaddress
 
 
 class Root:
@@ -31,10 +32,16 @@ class Root:
             self.mac_address = None
 
         try:
+            self.ip_address = None
             if self.hostname:
-                self.ip_address = socket.gethostbyname(self.hostname)
-            else:
-                self.ip_address = None
+                for info in socket.getaddrinfo(self.hostname, None):
+                    addr = info[4][0]
+                    try:
+                        if not ipaddress.ip_address(addr).is_loopback:
+                            self.ip_address = addr
+                            break
+                    except Exception:
+                        pass
         except Exception:
             self.ip_address = None
 


### PR DESCRIPTION
## Summary
- ignore loopback addresses when resolving IP in `Root`
- adjust tests for new logic and add tests for loopback filtering

## Testing
- `pip install jcs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b67609db0832ba4092245301b87af