### PR TITLE
Add username to Root info

### DIFF
--- a/src/efu/root.py
+++ b/src/efu/root.py
@@ -7,6 +7,7 @@ import jcs
 import hashlib
 import base64
 import ipaddress
+import getpass
 
 
 class Root:
@@ -17,11 +18,17 @@ class Root:
         self.mac_address: Optional[str] = None
         self.ip_address: Optional[str] = None
         self.path: Optional[str] = None
+        self.username: Optional[str] = None
 
         try:
             self.hostname = socket.gethostname()
         except Exception:
             self.hostname = None
+
+        try:
+            self.username = getpass.getuser()
+        except Exception:
+            self.username = None
 
         try:
             node = uuid.getnode()
@@ -70,6 +77,7 @@ class Root:
             "hostname": self.hostname,
             "ip_address": self.ip_address,
             "mac_address": self.mac_address,
+            "username": self.username,
             "path": self.path,
         }
         return jcs.canonicalize(data).decode("utf-8")
@@ -80,6 +88,7 @@ class Root:
             "hostname": self.hostname,
             "ip_address": self.ip_address,
             "mac_address": self.mac_address,
+            "username": self.username,
             "path": self.path,
         }
         return json.dumps(data, ensure_ascii=False, indent=2)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -6,6 +6,7 @@ import json
 import jcs
 import uuid
 import hashlib
+import getpass
 import os
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
@@ -18,6 +19,7 @@ def test_root_basic(tmp_path):
     assert r.hostname is None or isinstance(r.hostname, str)
     assert r.ip_address is None or isinstance(r.ip_address, str)
     assert r.mac_address is None or isinstance(r.mac_address, str)
+    assert r.username is None or isinstance(r.username, str)
 
 
 def test_hostname_failure(monkeypatch):
@@ -36,6 +38,7 @@ def test_hostname_failure(monkeypatch):
 def test_root_initialization():
     root = Root()
     assert root.hostname == socket.gethostname()
+    assert root.username == getpass.getuser()
 
 
 def test_root_default_path():
@@ -59,6 +62,7 @@ def test_to_json(tmp_path):
     js = r.to_json()
     data = json.loads(js)
     assert data['path'] == str(tmp_path)
+    assert data['username'] == r.username
     assert js == jcs.canonicalize(data).decode('utf-8')
 
 
@@ -67,6 +71,7 @@ def test_str(tmp_path):
     s = str(r)
     data = json.loads(s)
     assert data['path'] == str(tmp_path)
+    assert data['username'] == r.username
 
 
 def test_exclude_loopback(monkeypatch):


### PR DESCRIPTION
## Summary
- store username on `Root` via `getpass.getuser`
- include the username in `to_json` and `__str__`
- test that `username` is captured and emitted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b6a13a600832bb8fbc0bca3b97c3f